### PR TITLE
feat: update git precommit hook to re-add staged files for commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,10 +11,19 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# Capture originally staged files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
 echo "[pre-commit] Running Spotless format…"
 ./gradlew -q spotlessApply
 
 echo "[pre-commit] Running checks…"
 ./gradlew -q clean check
+
+# Re-add only the originally staged files
+if [[ -n "$STAGED_FILES" ]]; then
+  echo "[pre-commit] Re-staging originally staged files…"
+  echo "$STAGED_FILES" | xargs git add
+fi
 
 echo "[pre-commit] OK"

--- a/.githooks/pre-commit.cmd
+++ b/.githooks/pre-commit.cmd
@@ -8,6 +8,10 @@ IF "%SKIP_GIT_HOOKS%"=="1" (
 FOR /F "delims=" %%i IN ('git rev-parse --show-toplevel') DO SET REPO_ROOT=%%i
 cd /D "%REPO_ROOT%"
 
+REM Capture originally staged files
+SET STAGED_FILES_TEMP=%TEMP%\staged_files_%RANDOM%.txt
+git diff --cached --name-only --diff-filter=ACM > "%STAGED_FILES_TEMP%"
+
 echo [pre-commit] Running Spotless format…
 call gradlew.bat -q spotlessApply
 IF ERRORLEVEL 1 EXIT /B 1
@@ -15,5 +19,14 @@ IF ERRORLEVEL 1 EXIT /B 1
 echo [pre-commit] Running checks…
 call gradlew.bat -q clean check
 IF ERRORLEVEL 1 EXIT /B 1
+
+REM Re-add only the originally staged files
+echo [pre-commit] Re-staging originally staged files…
+FOR /F "delims=" %%f IN (%STAGED_FILES_TEMP%) DO (
+  git add "%%f"
+)
+
+REM Clean up temp file
+DEL "%STAGED_FILES_TEMP%"
 
 echo [pre-commit] OK

--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ At the time of writing this, a baseline/skeleton "Scaffold only" exists (Pre-rel
     rm -rf build .gradle
     ./gradlew clean check
     ```
+- **Undo local changes:** `git checkout -- .` (warning: discards uncommitted changes)
+- **Delete local branch:** `git branch -D <branch-name>`
+- **Sync local branch with remote:** `git fetch origin` then `git reset --hard origin/<branch-name>` (warning: discards uncommitted changes)
+- **Undo last commit but keep changes staged:** `git reset --soft HEAD~1` (useful if you forgot to run `spotlessApply` before committing or want to change commit message)
 You can always reach out to team members for troubleshooting help and questions via our Discord server (any channel, will update this when appropriate/specific channels are completely set up).
 
 **Any and all questions/requests welcomed**.


### PR DESCRIPTION
This pull request improves the reliability of the pre-commit hooks by ensuring only originally staged files are re-staged after formatting and checks, and updates the `README.md` with helpful Git commands for managing local changes. The most important changes are:

## What’s in this PR
Pre-commit hook improvements:
* In `.githooks/pre-commit`, the script now captures the list of originally staged files before running formatting and checks, and re-adds only those files to the staging area afterward. This prevents accidentally staging unrelated changes.
* In `.githooks/pre-commit.cmd`, similar logic is implemented for Windows: it saves the list of staged files to a temporary file, re-adds them after running checks, and cleans up the temp file. [[1]](diffhunk://#diff-853e265ef347e81222345b48a08009873b468de91b5516435c525a95394f0442R11-R14) [[2]](diffhunk://#diff-853e265ef347e81222345b48a08009873b468de91b5516435c525a95394f0442R23-R31)

Documentation update:
* The `README.md` now includes useful Git commands for undoing local changes, deleting branches, syncing with remote, and undoing the last commit while keeping changes staged.previously, staged files were formatted by spotless task but not re-added to the staging area after checks were run, which resulted in commits with unformatted/checked code.

## Why
Previously, staged files were formatted by spotless task but not re-added to the staging area after checks were run, which resulted in commits with unformatted/checked code.

## How to test
1. Follow instructions in README to setup/use the git pre-commit hooks.
2. Try a commit and when spotless task finishes during pre-commit run, the script will re-staged files and commit them.

## Checklist
- [x] Using JDK 21 locally (or `devcontainer` if using VSCode); Gradle wrapper used
- [x] Branch from `dev`, PR to `dev`
- [x] Ran `./gradlew spotlessApply` (auto-formatter)
- [x] `./gradlew clean check` passes locally
- [x] Docs updated if behavior/commands changed (`/docs` and/or README)
- [x] Base is `dev`. Will use **Merge** (not Squash/Rebase).
