### PR TITLE
feat: construct json files with values from SRS document

### DIFF
--- a/src/main/resources/data/items.json
+++ b/src/main/resources/data/items.json
@@ -1,0 +1,197 @@
+{
+  "items": [
+    {
+      "id": "IT-01",
+      "name": "Minor Healing Potion",
+      "description": "A simple potion brewed from low-tier herbs. Restores small vitality.",
+      "category": "Consumable",
+      "effect": "+20 HP",
+      "specialEffect": "None"
+    },
+    {
+      "id": "IT-02",
+      "name": "Greater Healing Potion",
+      "description": "A stronger potion infused with mana crystals.",
+      "category": "Consumable",
+      "effect": "+50 HP",
+      "specialEffect": "None"
+    },
+    {
+      "id": "IT-03",
+      "name": "Orc Axe",
+      "description": "A crude axe dropped by Orc Warriors.",
+      "category": "Weapon",
+      "effect": "+25 Damage",
+      "specialEffect": "Increases critical hit chance slightly."
+    },
+    {
+      "id": "IT-04",
+      "name": "High Orc Club",
+      "description": "A massive club wielded by Orc Chiefs.",
+      "category": "Weapon",
+      "effect": "+40 Damage",
+      "specialEffect": "Reduces enemy defense slightly on hit."
+    },
+    {
+      "id": "IT-05",
+      "name": "Kasaka's Venom Fang",
+      "description": "A dagger carved from Kasaka's fangs.",
+      "category": "Weapon",
+      "effect": "+35 Damage",
+      "specialEffect": "Applies poison (5 dmg/turn for 3 turns)."
+    },
+    {
+      "id": "IT-06",
+      "name": "Fire Sigil",
+      "description": "A glowing sigil infused with Pyros' essence.",
+      "category": "Key Item",
+      "effect": "",
+      "specialEffect": "Required for PUZ-10 Final Gate Seal."
+    },
+    {
+      "id": "IT-07",
+      "name": "Water Sigil",
+      "description": "A sigil pulsing with Neressa's aquatic energy.",
+      "category": "Key Item",
+      "effect": "",
+      "specialEffect": "Required for PUZ-10 Final Gate Seal."
+    },
+    {
+      "id": "IT-08",
+      "name": "Earth Sigil",
+      "description": "A heavy stone sigil infused with Gravemaw's power.",
+      "category": "Key Item",
+      "effect": "",
+      "specialEffect": "Required for PUZ-10 Final Gate Seal."
+    },
+    {
+      "id": "IT-09",
+      "name": "Air Sigil",
+      "description": "A feathered sigil infused with Zephyra's storm essence.",
+      "category": "Key Item",
+      "effect": "",
+      "specialEffect": "Required for PUZ-10 Final Gate Seal."
+    },
+    {
+      "id": "IT-10",
+      "name": "Cerberus Fang",
+      "description": "One of Cerberus's fangs, crackling with infernal energy.",
+      "category": "Weapon",
+      "effect": "+60 Damage",
+      "specialEffect": "10% chance to cause \"Bleed\" (HP loss/turn)."
+    },
+    {
+      "id": "IT-11",
+      "name": "Baruka's Twin Blades",
+      "description": "Dual cursed blades that hum with dark energy.",
+      "category": "Weapon",
+      "effect": "+70 Damage",
+      "specialEffect": "Can strike twice in one turn."
+    },
+    {
+      "id": "IT-12",
+      "name": "Demon King's Crown",
+      "description": "A crown radiating demonic authority.",
+      "category": "Artifact",
+      "effect": "",
+      "specialEffect": "Boosts overall stats by 15%."
+    },
+    {
+      "id": "IT-13",
+      "name": "Lich's Staff",
+      "description": "A staff dripping with necrotic energy.",
+      "category": "Weapon",
+      "effect": "+80 Damage",
+      "specialEffect": "Summons 2 skeletons to assist in combat."
+    },
+    {
+      "id": "IT-14",
+      "name": "Architect's Core",
+      "description": "A crystalline shard of Kandiaru's code.",
+      "category": "Artifact",
+      "effect": "",
+      "specialEffect": "Grants access to hidden PUZ-11 (Architect's Test)."
+    },
+    {
+      "id": "IT-15",
+      "name": "Ant King's Carapace",
+      "description": "A hardened shell fragment from the Ant King.",
+      "category": "Armor",
+      "effect": "",
+      "specialEffect": "Reduces incoming damage by 20%."
+    },
+    {
+      "id": "IT-16",
+      "name": "Frost Sigil",
+      "description": "A frozen sigil of the Frost Monarch.",
+      "category": "Key Item",
+      "effect": "",
+      "specialEffect": "Unlocks frost abilities."
+    },
+    {
+      "id": "IT-17",
+      "name": "Dragon's Fang Sword",
+      "description": "A legendary blade forged from Antares' fang.",
+      "category": "Weapon",
+      "effect": "+150 Damage",
+      "specialEffect": "Deals bonus damage to Monarch-class enemies."
+    },
+    {
+      "id": "IT-18",
+      "name": "Shadow Monarch's Cloak",
+      "description": "A cloak forged from shadows themselves.",
+      "category": "Artifact",
+      "effect": "",
+      "specialEffect": "Boosts Shadow Army size by +20%."
+    },
+    {
+      "id": "IT-19",
+      "name": "Rusted Trial Sword",
+      "description": "A faintly glowing sword from PUZ-07.",
+      "category": "Key Item",
+      "effect": "+10 Damage",
+      "specialEffect": "Required to break Final Gate."
+    },
+    {
+      "id": "IT-20",
+      "name": "System Blessing",
+      "description": "A permanent buff gained from PUZ-11.",
+      "category": "Artifact",
+      "effect": "+50 Max HP",
+      "specialEffect": "Cannot be removed; permanently increases HP."
+    },
+    {
+      "id": "IT-21",
+      "name": "Hunter's Leather Armor",
+      "description": "Basic armor crafted for new hunters.",
+      "category": "Armor",
+      "effect": "",
+      "specialEffect": "Increases Max HP from 100 → 150."
+    },
+    {
+      "id": "IT-22",
+      "name": "Steel Plate Mail",
+      "description": "Heavy defensive armor dropped by High Orc Chief.",
+      "category": "Armor",
+      "effect": "",
+      "specialEffect": "Increases Max HP from 150 → 200."
+    },
+    {
+      "id": "IT-23",
+      "name": "Dragonbone Armor",
+      "description": "Forged from fallen dragon remains.",
+      "category": "Armor",
+      "effect": "",
+      "specialEffect": "Increases Max HP from 200 → 250. Also reduces fire damage by 10%."
+    },
+    {
+      "id": "IT-24",
+      "name": "Shadow Monarch's Armor (optional)",
+      "description": "Legendary armor imbued with shadow energy, endgame gear.",
+      "category": "Armor",
+      "effect": "",
+      "specialEffect": "Increases Max HP cap permanently to 300. Stacks with System Blessing."
+    }
+  ]
+}
+

--- a/src/main/resources/data/monsters.json
+++ b/src/main/resources/data/monsters.json
@@ -1,0 +1,313 @@
+{
+  "monsters": [
+    {
+      "id": "MON-01",
+      "name": "Iron-Fanged Lycan",
+      "roomLocation": "RM-02",
+      "description": "A wolf-type beast with razor fangs, one of Jinwoo's earliest trials.",
+      "hp": 200,
+      "maxHp": 200,
+      "damage": 20,
+      "specialEffects": [
+        "Fast Bite (quick consecutive attacks)"
+      ],
+      "itemDrops": [
+        "Minor Healing Potion"
+      ]
+    },
+    {
+      "id": "MON-02",
+      "name": "Giant Statue",
+      "roomLocation": "RM-04, RM-06",
+      "description": "Colossal stone guardians from the Double Dungeon, capable of crushing hunters instantly.",
+      "hp": 500,
+      "maxHp": 500,
+      "damage": 50,
+      "specialEffects": [
+        "Stone Smash (instant kill if puzzle failed)"
+      ],
+      "itemDrops": []
+    },
+    {
+      "id": "MON-03",
+      "name": "Orc Warrior",
+      "roomLocation": "RM-09",
+      "description": "Brutal foot soldiers armed with crude weapons.",
+      "hp": 300,
+      "maxHp": 300,
+      "damage": 30,
+      "specialEffects": [
+        "Berserk Rage (+10 damage when HP < 100)"
+      ],
+      "itemDrops": [
+        "Orc Axe"
+      ]
+    },
+    {
+      "id": "MON-04",
+      "name": "High Orc Chief",
+      "roomLocation": "RM-25",
+      "description": "A powerful chieftain commanding orc clans.",
+      "hp": 700,
+      "maxHp": 700,
+      "damage": 60,
+      "specialEffects": [
+        "War Cry (reduces player defense by 20%)"
+      ],
+      "itemDrops": [
+        "High Orc Club",
+        "Steel Plate Mail"
+      ]
+    },
+    {
+      "id": "MON-05",
+      "name": "Kasaka (Blue Venom-Fanged Snake)",
+      "roomLocation": "RM-05",
+      "description": "A giant venomous serpent that ambushes players in ruined areas.",
+      "hp": 400,
+      "maxHp": 400,
+      "damage": 35,
+      "specialEffects": [
+        "Venom Bite (poison damage over 3 turns)"
+      ],
+      "itemDrops": [
+        "Kasaka's Venom Fang (dagger weapon)"
+      ]
+    },
+    {
+      "id": "MON-06",
+      "name": "Pyros, Infernal Sentinel",
+      "roomLocation": "RM-10",
+      "description": "Elemental Fire Boss clad in molten armor, wields devastating flame attacks.",
+      "hp": 1200,
+      "maxHp": 1200,
+      "damage": 100,
+      "specialEffects": [
+        "Fire Breath (burn for 5-10 seconds)",
+        "Lava Geyser (AoE damage)"
+      ],
+      "itemDrops": [
+        "Fire Sigil"
+      ]
+    },
+    {
+      "id": "MON-07",
+      "name": "Neressa, Tidebinder",
+      "roomLocation": "RM-11",
+      "description": "Elemental Water Boss, cloaked in streams and illusions.",
+      "hp": 1200,
+      "maxHp": 1200,
+      "damage": 90,
+      "specialEffects": [
+        "Drowning Currents (damage over time)",
+        "Clone Summon (creates water illusions)"
+      ],
+      "itemDrops": [
+        "Water Sigil"
+      ]
+    },
+    {
+      "id": "MON-08",
+      "name": "Gravemaw, Stone Colossus",
+      "roomLocation": "RM-12",
+      "description": "Elemental Earth Boss, a titan that crushes everything in its path.",
+      "hp": 1300,
+      "maxHp": 1300,
+      "damage": 110,
+      "specialEffects": [
+        "Earthquake (stuns for 2 turns)",
+        "Boulder Crash"
+      ],
+      "itemDrops": [
+        "Earth Sigil"
+      ]
+    },
+    {
+      "id": "MON-09",
+      "name": "Zephyra, Storm Matron",
+      "roomLocation": "RM-13",
+      "description": "Elemental Air Boss, commanding winds and lightning.",
+      "hp": 1250,
+      "maxHp": 1250,
+      "damage": 95,
+      "specialEffects": [
+        "Cyclone Push (knockback)",
+        "Lightning Strike (high burst damage)"
+      ],
+      "itemDrops": [
+        "Air Sigil"
+      ]
+    },
+    {
+      "id": "MON-10",
+      "name": "Cerberus",
+      "roomLocation": "RM-15",
+      "description": "A massive three-headed hound that guards the inner chambers.",
+      "hp": 1400,
+      "maxHp": 1400,
+      "damage": 120,
+      "specialEffects": [
+        "Triple Bite (3 consecutive attacks in one turn)"
+      ],
+      "itemDrops": [
+        "Cerberus Fang"
+      ]
+    },
+    {
+      "id": "MON-11",
+      "name": "Baruka",
+      "roomLocation": "RM-15",
+      "description": "A Demon Castle general wielding dark magic and blades.",
+      "hp": 1000,
+      "maxHp": 1000,
+      "damage": 85,
+      "specialEffects": [
+        "Shadow Slash (high crit chance)"
+      ],
+      "itemDrops": [
+        "Baruka's Twin Blades"
+      ]
+    },
+    {
+      "id": "MON-12",
+      "name": "Baran, Demon King",
+      "roomLocation": "RM-16",
+      "description": "Demon King, one of the overlords of the Demon Castle.",
+      "hp": 1500,
+      "maxHp": 1500,
+      "damage": 130,
+      "specialEffects": [
+        "Lightning Storm (multi-target AoE)",
+        "Dark Roar"
+      ],
+      "itemDrops": [
+        "Demon King's Crown"
+      ]
+    },
+    {
+      "id": "MON-13",
+      "name": "Arch Lich",
+      "roomLocation": "RM-15, RM-16",
+      "description": "Powerful undead mages controlling skeleton armies.",
+      "hp": 900,
+      "maxHp": 900,
+      "damage": 70,
+      "specialEffects": [
+        "Dark Bolt",
+        "Summon Skeletons (adds minions)"
+      ],
+      "itemDrops": [
+        "Lich's Staff"
+      ]
+    },
+    {
+      "id": "MON-14",
+      "name": "Kandiaru, the System's Architect",
+      "roomLocation": "RM-17",
+      "description": "The Architect of the System, testing hunters with deadly illusions.",
+      "hp": 1600,
+      "maxHp": 1600,
+      "damage": 100,
+      "specialEffects": [
+        "Reality Warp (randomized debuffs, illusions)"
+      ],
+      "itemDrops": [
+        "Architect's Core"
+      ]
+    },
+    {
+      "id": "MON-15",
+      "name": "Ant King",
+      "roomLocation": "RM-20",
+      "description": "The apex predator of Jeju Island, feared even by S-rank hunters.",
+      "hp": 1800,
+      "maxHp": 1800,
+      "damage": 140,
+      "specialEffects": [
+        "Frenzied Slash",
+        "Poison Claw (HP degeneration over time)"
+      ],
+      "itemDrops": [
+        "Ant King's Carapace",
+        "Dragonbone Armor"
+      ]
+    },
+    {
+      "id": "MON-16",
+      "name": "Frost Monarch",
+      "roomLocation": "RM-18",
+      "description": "A powerful Monarch who commands ice storms and frost beasts.",
+      "hp": 1700,
+      "maxHp": 1700,
+      "damage": 130,
+      "specialEffects": [
+        "Ice Prison (immobilize 2 turns)",
+        "Frost Aura (lingering freeze effect)"
+      ],
+      "itemDrops": [
+        "Frost Sigil"
+      ]
+    },
+    {
+      "id": "MON-17",
+      "name": "Hwang Dong-soo",
+      "roomLocation": "RM-21",
+      "description": "A rogue human hunter antagonizing Jinwoo and others.",
+      "hp": 800,
+      "maxHp": 800,
+      "damage": 70,
+      "specialEffects": [
+        "Brutal Slash (high damage crit)"
+      ],
+      "itemDrops": []
+    },
+    {
+      "id": "MON-18",
+      "name": "Kang Taeshik",
+      "roomLocation": "RM-22",
+      "description": "A corrupt hunter who betrays his comrades.",
+      "hp": 700,
+      "maxHp": 700,
+      "damage": 60,
+      "specialEffects": [
+        "Backstab Critical (bonus damage from behind)"
+      ],
+      "itemDrops": []
+    },
+    {
+      "id": "MON-19",
+      "name": "Architect Guardian",
+      "roomLocation": "RM-23",
+      "description": "A hidden boss who manipulates dungeon structures and players.",
+      "hp": 1500,
+      "maxHp": 1500,
+      "damage": 120,
+      "specialEffects": [
+        "Summon Constructs",
+        "Energy Beam (piercing attack)"
+      ],
+      "itemDrops": [
+        "Architect's Relic"
+      ]
+    },
+    {
+      "id": "MON-20",
+      "name": "Antares, Monarch of Destruction",
+      "roomLocation": "RM-30",
+      "description": "The King of Dragons, Monarch of Destruction, the final antagonist.",
+      "hp": 2000,
+      "maxHp": 2000,
+      "damage": 150,
+      "specialEffects": [
+        "Fire Breath (burn for 10s)",
+        "Dragon Roar (stuns 3 turns)",
+        "Shadow Dominion (summons shadows)"
+      ],
+      "itemDrops": [
+        "Dragon's Fang Sword",
+        "Shadow Crystal",
+        "Shadow Monarch's Armor (optional)"
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/puzzles.json
+++ b/src/main/resources/data/puzzles.json
@@ -1,0 +1,124 @@
+{
+  "puzzles": [
+    {
+      "id": "PUZ-01",
+      "name": "Trial of the Statues",
+      "description": "Towering gods demand worship. Several statues hold weapons, while one holds nothing.",
+      "solution": "Kneel only before the statue with no weapon. Choosing wrong is fatal.",
+      "reward": "Unlocks passage to the Fire Chamber.",
+      "failureConsequence": "Instant death → respawn at Guild Hall.",
+      "commandUsed": "kneel statue / solve puzzle",
+      "numberOfAttempts": 1
+    },
+    {
+      "id": "PUZ-02",
+      "name": "Lava Stepping Stones",
+      "description": "In Pyros' Fire Chamber, rocks float across a lava river. Some are solid, others crack when stepped on.",
+      "solution": "Time your movements carefully, and hop only on the solid stones.",
+      "reward": "Safe path across the lava river to boss arena.",
+      "failureConsequence": "Fall into lava → lose HP and restart at riverbank.",
+      "commandUsed": "jump stone / solve puzzle",
+      "numberOfAttempts": 3
+    },
+    {
+      "id": "PUZ-03",
+      "name": "Water Cavern Flood Puzzle",
+      "description": "Neressa raises the water level, forcing hunters onto ledges. Coral pillars glow faintly in sequence.",
+      "solution": "Activate the coral pillars in the correct glowing order.",
+      "reward": "Lowers water, exposing boss Neressa.",
+      "failureConsequence": "Drowned → respawn at cavern entrance.",
+      "commandUsed": "activate pillar / solve puzzle",
+      "numberOfAttempts": 3
+    },
+    {
+      "id": "PUZ-04",
+      "name": "Earth Fortress Boulder Lock",
+      "description": "Gravemaw blocks the path with enormous rune-marked boulders that rearrange when struck.",
+      "solution": "Strike runes in correct sequence (clues hidden on walls).",
+      "reward": "Unlocks Gravemaw's inner chamber.",
+      "failureConsequence": "Puzzle resets, no progress until correct order is found.",
+      "commandUsed": "strike rune / solve puzzle",
+      "numberOfAttempts": "Unlimited (resets until correct)"
+    },
+    {
+      "id": "PUZ-05",
+      "name": "Air Spire Bridge Gusts",
+      "description": "Zephyra summons fierce gusts across a high bridge. Glowing feathers scatter mid-air.",
+      "solution": "Collect feathers and use them as anchors to weigh down the bridge.",
+      "reward": "Allows safe crossing to Zephyra's throne.",
+      "failureConsequence": "Knocked off bridge → lose HP and restart at bridge start.",
+      "commandUsed": "collect feather / solve puzzle",
+      "numberOfAttempts": 3
+    },
+    {
+      "id": "PUZ-06",
+      "name": "Rune Circle of Shadows",
+      "description": "In the Demon Castle Library, a giant rune circle glows on the floor, shifting constantly. Dark whispers dare entry.",
+      "solution": "Step on runes in the correct order matching the chant.",
+      "reward": "Unlocks hidden grimoire granting shadow power.",
+      "failureConsequence": "Wrong rune = shadow attack (HP loss), puzzle resets.",
+      "commandUsed": "step rune / solve puzzle",
+      "numberOfAttempts": "Unlimited (resets until correct)"
+    },
+    {
+      "id": "PUZ-07",
+      "name": "Eternal Battlefield Weapon Trial",
+      "description": "Spirits mislead adventurers among scattered weapons. Only one sword can pierce the Final Gate.",
+      "solution": "Choose the rusted sword that glows faintly when lifted.",
+      "reward": "Sword is required to break the seal of the Final Gate, Hunter's Leather Armor.",
+      "failureConsequence": "Choosing wrong weapon = cursed → HP drain / respawn.",
+      "commandUsed": "choose sword / solve puzzle",
+      "numberOfAttempts": 2
+    },
+    {
+      "id": "PUZ-08",
+      "name": "Shadow Army Summoning",
+      "description": "On the Shadow Plains, fallen souls rise but scatter without command.",
+      "solution": "Issue the correct command phrase to bind them.",
+      "reward": "Adds shadows as allies in later battles.",
+      "failureConsequence": "Failure → shadows disperse, retry possible.",
+      "commandUsed": "say arise / solve puzzle",
+      "numberOfAttempts": "Unlimited (retry allowed)"
+    },
+    {
+      "id": "PUZ-09",
+      "name": "Monarch's Throne Riddle",
+      "description": "From the obsidian throne, a riddle echoes: \"What walks with no legs, speaks with no mouth, and follows yet leads?\"",
+      "solution": "Answer: Shadow.",
+      "reward": "Unlocks final throne room and Monarch's audience.",
+      "failureConsequence": "Wrong answer → immediate expulsion from throne room.",
+      "commandUsed": "answer shadow / solve puzzle",
+      "numberOfAttempts": 1
+    },
+    {
+      "id": "PUZ-10",
+      "name": "Final Gate Seal",
+      "description": "A colossal rift sealed by four elemental emblems (Fire, Water, Earth, Air).",
+      "solution": "Collect all 4 sigils from bosses and place them into the gate lock.",
+      "reward": "The Final Gate opens → last boss fight / ending.",
+      "failureConsequence": "Missing sigils → gate remains sealed, cannot progress.",
+      "commandUsed": "place sigil / solve puzzle",
+      "numberOfAttempts": "Unlimited (progress-gated)"
+    },
+    {
+      "id": "PUZ-11",
+      "name": "Architect's Test",
+      "description": "Kandiaru, the Architect, forces you to input the correct sequence of glowing runes that represent the System's code.",
+      "solution": "Enter runes in the correct sequence to stabilize the System.",
+      "reward": "Gain \"System Blessing\" (+50 Max HP).",
+      "failureConsequence": "HP drains steadily until puzzle resets.",
+      "commandUsed": "input code / solve puzzle",
+      "numberOfAttempts": 3
+    },
+    {
+      "id": "PUZ-12",
+      "name": "Shadow Monarch's Choice",
+      "description": "At the Monarch's Throne, shadows whisper: \"Will you embrace dominion or resist?\"",
+      "solution": "Choose to embrace shadows or resist shadows.",
+      "reward": "Determines alternate ending path (Shadow Monarch Ending vs Hunter King Ending).",
+      "failureConsequence": "Wrong choice or indecision = lose all Shadow Army allies and get expelled.",
+      "commandUsed": "embrace shadows / resist shadows",
+      "numberOfAttempts": 1
+    }
+  ]
+}

--- a/src/main/resources/data/world.json
+++ b/src/main/resources/data/world.json
@@ -1,0 +1,365 @@
+{
+  "rooms": [
+    {
+      "id": "RM-01",
+      "name": "Hunters Guild Hall",
+      "description": "The bustling headquarters where hunters gather before raids. Wooden notice boards overflow with dungeon postings. Hunters brag loudly while sharpening weapons. The air reeks of mana and ambition.",
+      "exits": {
+        "NORTH": "RM-02",
+        "EAST": "RM-03"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-02",
+      "name": "Tutorial Dungeon Entrance",
+      "description": "A damp stone stairwell descends into shadow. Strange markings crawl across the walls, pulsing faint blue. The air is heavy — almost warning you not to enter.",
+      "exits": {
+        "SOUTH": "RM-01",
+        "NORTH": "RM-04"
+      },
+      "monsters": ["MON-01"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-03",
+      "name": "Dungeon Lobby",
+      "description": "A circular chamber lined with glowing crystals. Adventurers use this as a staging ground. The silence beyond the sealed doors chills the bones.",
+      "exits": {
+        "WEST": "RM-01",
+        "EAST": "RM-05"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-04",
+      "name": "Statue Chamber",
+      "description": "Gigantic godlike statues loom in eternal judgment. Their stone eyes follow your every move. The silence here is suffocating, broken only by the distant scrape of stone.",
+      "exits": {
+        "SOUTH": "RM-02",
+        "NORTH": "RM-06"
+      },
+      "monsters": ["MON-02"],
+      "items": [],
+      "puzzles": ["PUZ-01"]
+    },
+    {
+      "id": "RM-05",
+      "name": "Ruined City Street",
+      "description": "Shattered skyscrapers pierce the sky like jagged teeth. Cars lie rusting, abandoned mid-flight from disaster. Shadows dart across broken glass.",
+      "exits": {
+        "WEST": "RM-03",
+        "EAST": "RM-07"
+      },
+      "monsters": ["MON-05"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-06",
+      "name": "Double Dungeon Altar",
+      "description": "A massive altar engraved with runes. Dried blood stains the floor. The rules of survival are etched in stone: \"Worship the gods.\"",
+      "exits": {
+        "SOUTH": "RM-04",
+        "NORTH": "RM-08"
+      },
+      "monsters": ["MON-02"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-07",
+      "name": "Gate Plaza",
+      "description": "A glowing rift shimmers in the air. Hunters mill nervously nearby, checking gear before stepping into the unknown. Beyond the light is chaos.",
+      "exits": {
+        "WEST": "RM-05",
+        "EAST": "RM-09"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-08",
+      "name": "Cursed Statue Throne",
+      "description": "A towering statue sits upon a throne, holding a severed head. Its gaze demands obedience. The air hums with divine hostility.",
+      "exits": {
+        "SOUTH": "RM-06",
+        "NORTH": "RM-10"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-09",
+      "name": "Orc Encampment",
+      "description": "Fires burn in cracked barrels. The stench of roasted meat and unwashed bodies fills the night. Orcs snarl and argue, their crude weapons gleaming.",
+      "exits": {
+        "WEST": "RM-07",
+        "EAST": "RM-11"
+      },
+      "monsters": ["MON-03"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-10",
+      "name": "Fire Chamber",
+      "description": "A cavern of lava rivers and scorched stone. Pyros towers here, molten cracks glowing across his armor. He hurls fireballs at stepping stones, summons geysers, and turns the air into firestorms. Weakness: water. Hint: \"Only the endless flow quenches the flame...\"",
+      "exits": {
+        "SOUTH": "RM-08",
+        "NORTH": "RM-11"
+      },
+      "monsters": ["MON-06"],
+      "items": [],
+      "puzzles": ["PUZ-02"]
+    },
+    {
+      "id": "RM-11",
+      "name": "Water Cavern",
+      "description": "A shimmering cave of coral and flooding chambers. Neressa rises, cloaked in flowing water. She raises currents, drowning traps, and watery clones. Weakness: earth. Hint: \"Stone alone withstands the tide...\"",
+      "exits": {
+        "SOUTH": "RM-10",
+        "NORTH": "RM-12"
+      },
+      "monsters": ["MON-07"],
+      "items": [],
+      "puzzles": ["PUZ-03"]
+    },
+    {
+      "id": "RM-12",
+      "name": "Earth Fortress",
+      "description": "A titanic stone hall with shifting walls. Gravemaw stomps, creating earthquakes and stone spikes while boulders crash overhead. Weakness: wind. Hint: \"Only the wind wears away the mountain...\"",
+      "exits": {
+        "SOUTH": "RM-11",
+        "NORTH": "RM-13"
+      },
+      "monsters": ["MON-08"],
+      "items": [],
+      "puzzles": ["PUZ-04"]
+    },
+    {
+      "id": "RM-13",
+      "name": "Air Spire",
+      "description": "A tower of sky bridges and roaring winds. Zephyra floats above, summoning cyclones and lightning strikes, pushing hunters into the void. Weakness: fire. Hint: \"Flames rise to consume the sky once more...\"",
+      "exits": {
+        "SOUTH": "RM-12",
+        "NORTH": "RM-14"
+      },
+      "monsters": ["MON-09"],
+      "items": [],
+      "puzzles": ["PUZ-05"]
+    },
+    {
+      "id": "RM-14",
+      "name": "Demon Castle Foyer",
+      "description": "Immense gates open into a crimson-lit hall. Demonic runes glow on towering pillars. Every step feels like blasphemy.",
+      "exits": {
+        "SOUTH": "RM-13",
+        "NORTH": "RM-15"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-15",
+      "name": "Demon Castle Library",
+      "description": "Thousands of cursed tomes float mid-air, pages turning by themselves. Whispers seep into your mind, urging you to read forbidden knowledge.",
+      "exits": {
+        "SOUTH": "RM-14",
+        "NORTH": "RM-16"
+      },
+      "monsters": ["MON-10", "MON-11", "MON-13"],
+      "items": [],
+      "puzzles": ["PUZ-06"]
+    },
+    {
+      "id": "RM-16",
+      "name": "Demon Castle Throne Room",
+      "description": "A long red carpet leads to a massive black throne. Claws have shredded the walls. Demonic energy radiates like a heartbeat.",
+      "exits": {
+        "SOUTH": "RM-15",
+        "NORTH": "RM-17"
+      },
+      "monsters": ["MON-12", "MON-13"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-17",
+      "name": "Monarch's Chamber",
+      "description": "The oppressive presence of a Monarch fills the room. Cracks of black lightning scorch the marble floor. The air vibrates with raw dominion.",
+      "exits": {
+        "SOUTH": "RM-16",
+        "NORTH": "RM-18"
+      },
+      "monsters": ["MON-14"],
+      "items": [],
+      "puzzles": ["PUZ-11"]
+    },
+    {
+      "id": "RM-18",
+      "name": "Dimensional Rift",
+      "description": "A swirling vortex of space and time. Gravity bends oddly here. Your reflection flickers in the void, smiling back differently.",
+      "exits": {
+        "SOUTH": "RM-17",
+        "NORTH": "RM-19"
+      },
+      "monsters": ["MON-16"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-19",
+      "name": "Hunters Association Office",
+      "description": "Suits and uniforms bustle about, papers stacked high. Giant holographic maps of gates flicker overhead. This is the heart of strategy.",
+      "exits": {
+        "SOUTH": "RM-18",
+        "NORTH": "RM-20"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-20",
+      "name": "Eternal Battlefield",
+      "description": "Swords and shields from countless ages litter the field. Spirits of warriors wander aimlessly, reliving endless war.",
+      "exits": {
+        "SOUTH": "RM-19",
+        "NORTH": "RM-21"
+      },
+      "monsters": ["MON-15"],
+      "items": [],
+      "puzzles": ["PUZ-07"]
+    },
+    {
+      "id": "RM-21",
+      "name": "Hospital Ward",
+      "description": "Rows of hunters lie unconscious. Nurses rush between beds, mana stones glowing faintly in medical equipment. A sense of fragility lingers.",
+      "exits": {
+        "SOUTH": "RM-20",
+        "NORTH": "RM-22"
+      },
+      "monsters": ["MON-17"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-22",
+      "name": "Hunter Exam Arena",
+      "description": "Stone coliseum seats tower overhead. Spectators roar as new hunters prove themselves. Mana signatures burst like fireworks in the air.",
+      "exits": {
+        "SOUTH": "RM-21",
+        "NORTH": "RM-23"
+      },
+      "monsters": ["MON-18"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-23",
+      "name": "Dungeon Boss Chamber",
+      "description": "Bones crunch underfoot. A monstrous roar echoes. The boss lurks just beyond the shadows, its breath shaking the walls.",
+      "exits": {
+        "SOUTH": "RM-22",
+        "NORTH": "RM-24"
+      },
+      "monsters": ["MON-19"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-24",
+      "name": "Shadow Army Plains",
+      "description": "Rolling plains stretch endlessly. A black mist rises from the soil. The whispers of fallen shadows gather around you, waiting for command.",
+      "exits": {
+        "SOUTH": "RM-23",
+        "NORTH": "RM-25"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": ["PUZ-08"]
+    },
+    {
+      "id": "RM-25",
+      "name": "High Orc Fortress",
+      "description": "Heavy wooden gates bar the path. Drums thunder inside, announcing your arrival. The stench of sweat and iron fills the air.",
+      "exits": {
+        "SOUTH": "RM-24",
+        "NORTH": "RM-26"
+      },
+      "monsters": ["MON-04"],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-26",
+      "name": "Hunters' Cafeteria",
+      "description": "A surprisingly normal room. Hunters chat over coffee and ramen. Laughter briefly masks the dread of their next raid.",
+      "exits": {
+        "SOUTH": "RM-25",
+        "NORTH": "RM-27"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-27",
+      "name": "Blacksmith's Forge",
+      "description": "Sparks fly as weapons are reforged. The smell of molten metal and mana crystals fusing fills the room. Each strike resonates with power.",
+      "exits": {
+        "SOUTH": "RM-26",
+        "NORTH": "RM-28"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-28",
+      "name": "Monarch's Throne",
+      "description": "The throne of destruction towers, larger than life. The Monarch of Shadows gazes upon the battlefield with infinite weight.",
+      "exits": {
+        "SOUTH": "RM-27",
+        "NORTH": "RM-29"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": ["PUZ-09", "PUZ-12"]
+    },
+    {
+      "id": "RM-29",
+      "name": "Monarch's Throne of Darkness",
+      "description": "Darkness itself gathers like liquid. The shadows bow to you here. Every whisper feels like a promise of more power.",
+      "exits": {
+        "SOUTH": "RM-28",
+        "NORTH": "RM-30"
+      },
+      "monsters": [],
+      "items": [],
+      "puzzles": []
+    },
+    {
+      "id": "RM-30",
+      "name": "Final Gate",
+      "description": "A colossal rift glowing brighter than the sun. Beyond it lies the endgame — the fate of hunters, Monarchs, and the world itself.",
+      "exits": {
+        "SOUTH": "RM-29"
+      },
+      "monsters": ["MON-20"],
+      "items": [],
+      "puzzles": ["PUZ-10"]
+    }
+  ],
+  "startingRoomId": "RM-01"
+}
+


### PR DESCRIPTION
## What’s in this PR

This pull request introduces comprehensive new game data for items, monsters, and puzzles by adding three large JSON files. These files define the core entities and mechanics for the game, including consumables, weapons, artifacts, armor, key items, boss monsters, and environmental puzzles. The data is structured to support game logic, progression, and reward systems.

**Game Data Additions**

*Items and Equipment:*
- Added `items.json` containing 24 distinct items, including consumables, weapons, armor, artifacts, and key items. Each item features unique effects and special abilities, such as stat boosts, elemental powers, and puzzle progression requirements.

*Monsters and Bosses:*
- Added `monsters.json` with 20 monsters, detailing their stats, locations, abilities, and item drops. Includes regular enemies, elemental bosses, human antagonists, and endgame Monarch-class foes.

*Puzzles and Progression:*
- Added `puzzles.json` with 12 puzzles, each describing a unique challenge, solution, rewards, failure consequences, and relevant commands. Puzzles are tied to dungeon progression, boss encounters, and alternate endings.

