### PR TITLE
Implement player stats command with equipment integration

### DIFF
--- a/game/src/main/java/avengers/client/command/InputCommandParser.java
+++ b/game/src/main/java/avengers/client/command/InputCommandParser.java
@@ -145,6 +145,10 @@ public class InputCommandParser implements CommandParser {
     // System verbs
     verbMap.put("help", Verb.HELP);
     verbMap.put("?", Verb.HELP);
+    verbMap.put("stats", Verb.STATS);
+    verbMap.put("status", Verb.STATS);
+    verbMap.put("character", Verb.STATS);
+    verbMap.put("info", Verb.STATS);
     verbMap.put("save", Verb.SAVE);
     verbMap.put("load", Verb.LOAD);
     verbMap.put("quit", Verb.QUIT);

--- a/game/src/main/java/avengers/client/controller/SystemController.java
+++ b/game/src/main/java/avengers/client/controller/SystemController.java
@@ -4,6 +4,8 @@ import avengers.domain.model.World;
 import avengers.domain.utils.CommandResult;
 import avengers.domain.utils.CommandToken;
 import avengers.domain.utils.GameContext;
+import avengers.domain.utils.Verb;
+import avengers.service.ExplorationService;
 import avengers.service.SaveService;
 import avengers.service.world.WorldLoader;
 
@@ -11,11 +13,13 @@ import avengers.service.world.WorldLoader;
 public class SystemController implements CommandController {
   private final SaveService save;
   private final WorldLoader worldLoader;
+  private final ExplorationService explorationService;
 
-  /** Constructs a SystemController with the given SaveService, ConsoleView, and WorldLoader. */
-  public SystemController(SaveService save, WorldLoader worldLoader) {
+  /** Constructs a SystemController with the given SaveService, WorldLoader, and ExplorationService. */
+  public SystemController(SaveService save, WorldLoader worldLoader, ExplorationService explorationService) {
     this.save = save;
     this.worldLoader = worldLoader;
+    this.explorationService = explorationService;
   }
 
   /** Handles system commands and returns the result. */
@@ -37,6 +41,7 @@ public class SystemController implements CommandController {
                   + "  use <item> - Use an item\n"
                   + "  attack <monster> - Attack a monster (starts combat)\n"
                   + "  ignore <monster> - Ignore a monster (makes it disappear)\n"
+                  + "  stats - Display player stats and equipped items\n"
                   + "  save - Save your game\n"
                   + "  quit - Save and quit the game");
       case SAVE -> {
@@ -62,6 +67,7 @@ public class SystemController implements CommandController {
                 + "All monsters, items, and puzzles have been reset.\n"
                 + "Type 'look' to see your surroundings.");
       }
+      case Verb.STATS -> CommandResult.success(explorationService.showStats(ctx));
       case QUIT -> {
         save.saveData(ctx);
         yield CommandResult.exit("Game saved. Goodbye!");

--- a/game/src/main/java/avengers/client/controller/SystemController.java
+++ b/game/src/main/java/avengers/client/controller/SystemController.java
@@ -15,8 +15,11 @@ public class SystemController implements CommandController {
   private final WorldLoader worldLoader;
   private final ExplorationService explorationService;
 
-  /** Constructs a SystemController with the given SaveService, WorldLoader, and ExplorationService. */
-  public SystemController(SaveService save, WorldLoader worldLoader, ExplorationService explorationService) {
+  /**
+   * Constructs a SystemController with the given SaveService, WorldLoader, and ExplorationService.
+   */
+  public SystemController(
+      SaveService save, WorldLoader worldLoader, ExplorationService explorationService) {
     this.save = save;
     this.worldLoader = worldLoader;
     this.explorationService = explorationService;

--- a/game/src/main/java/avengers/client/runtime/ClientApp.java
+++ b/game/src/main/java/avengers/client/runtime/ClientApp.java
@@ -8,6 +8,8 @@ import avengers.domain.model.Player;
 import avengers.domain.model.World;
 import avengers.domain.utils.GameContext;
 import avengers.domain.utils.VerbCategory;
+import avengers.service.DefaultExplorationService;
+import avengers.service.ExplorationService;
 import avengers.service.SaveService;
 import avengers.service.spi.FileSaveRepository;
 import avengers.service.world.JsonWorldLoader;
@@ -33,12 +35,15 @@ public class ClientApp {
     var saveDirectory = Path.of(savesPath).toAbsolutePath();
     SaveService saveService = new SaveService(new FileSaveRepository(saveDirectory));
 
+    // init services
+    ExplorationService explorationService = new DefaultExplorationService();
+    
     // init controllers here
     CommandController movementController = new MovementController();
     CommandController inventoryController = new InventoryController();
     CommandController interactionController = new InteractionController();
     CommandController combatController = new CombatController();
-    CommandController systemController = new SystemController(saveService, loader);
+    CommandController systemController = new SystemController(saveService, loader, explorationService);
 
     // init game controller (main controller)
     GameController gameController =

--- a/game/src/main/java/avengers/client/runtime/ClientApp.java
+++ b/game/src/main/java/avengers/client/runtime/ClientApp.java
@@ -37,13 +37,14 @@ public class ClientApp {
 
     // init services
     ExplorationService explorationService = new DefaultExplorationService();
-    
+
     // init controllers here
     CommandController movementController = new MovementController();
     CommandController inventoryController = new InventoryController();
     CommandController interactionController = new InteractionController();
     CommandController combatController = new CombatController();
-    CommandController systemController = new SystemController(saveService, loader, explorationService);
+    CommandController systemController =
+        new SystemController(saveService, loader, explorationService);
 
     // init game controller (main controller)
     GameController gameController =

--- a/game/src/main/java/avengers/domain/model/Player.java
+++ b/game/src/main/java/avengers/domain/model/Player.java
@@ -206,8 +206,8 @@ public final class Player extends Character {
   }
 
   /**
-   * Calculates equipment bonuses for the player based on equipped items.
-   * This method requires a World instance to look up item effects.
+   * Calculates equipment bonuses for the player based on equipped items. This method requires a
+   * World instance to look up item effects.
    *
    * @param world the game world containing item definitions
    * @return StatBonus object containing all equipment bonuses
@@ -218,17 +218,24 @@ public final class Player extends Character {
 
     for (String itemId : equippedItems.values()) {
       if (itemId != null) {
-        world.findItem(itemId).ifPresent(item -> {
-          if (item.hasEffect()) {
-            StatBonus itemBonus = StatBonus.parseEffect(item.getEffect());
-            // Combine flat bonuses
-            itemBonus.getAllBonuses().forEach((stat, bonus) ->
-                totalBonuses.merge(stat, bonus, Integer::sum));
-            // Combine percentage bonuses
-            itemBonus.getAllPercentageBonuses().forEach((stat, bonus) ->
-                totalPercentageBonuses.merge(stat, bonus, Double::sum));
-          }
-        });
+        world
+            .findItem(itemId)
+            .ifPresent(
+                item -> {
+                  if (item.hasEffect()) {
+                    StatBonus itemBonus = StatBonus.parseEffect(item.getEffect());
+                    // Combine flat bonuses
+                    itemBonus
+                        .getAllBonuses()
+                        .forEach((stat, bonus) -> totalBonuses.merge(stat, bonus, Integer::sum));
+                    // Combine percentage bonuses
+                    itemBonus
+                        .getAllPercentageBonuses()
+                        .forEach(
+                            (stat, bonus) ->
+                                totalPercentageBonuses.merge(stat, bonus, Double::sum));
+                  }
+                });
       }
     }
 
@@ -244,14 +251,15 @@ public final class Player extends Character {
   public int getTotalAttack(World world) {
     StatBonus equipmentBonus = calculateEquipmentBonuses(world);
     int totalAttack = getBaseAttack() + equipmentBonus.getAttackBonus();
-    
+
     // Apply percentage bonuses
-    double percentageBonus = equipmentBonus.getPercentageBonus("Attack") + 
-                           equipmentBonus.getPercentageBonus("all stats");
+    double percentageBonus =
+        equipmentBonus.getPercentageBonus("Attack")
+            + equipmentBonus.getPercentageBonus("all stats");
     if (percentageBonus != 0) {
       totalAttack = (int) Math.round(totalAttack * (1 + percentageBonus / 100.0));
     }
-    
+
     return totalAttack;
   }
 
@@ -264,14 +272,15 @@ public final class Player extends Character {
   public int getTotalDefense(World world) {
     StatBonus equipmentBonus = calculateEquipmentBonuses(world);
     int totalDefense = getBaseDefense() + equipmentBonus.getDefenseBonus();
-    
+
     // Apply percentage bonuses
-    double percentageBonus = equipmentBonus.getPercentageBonus("Defense") + 
-                           equipmentBonus.getPercentageBonus("all stats");
+    double percentageBonus =
+        equipmentBonus.getPercentageBonus("Defense")
+            + equipmentBonus.getPercentageBonus("all stats");
     if (percentageBonus != 0) {
       totalDefense = (int) Math.round(totalDefense * (1 + percentageBonus / 100.0));
     }
-    
+
     return totalDefense;
   }
 
@@ -284,15 +293,16 @@ public final class Player extends Character {
   public int getTotalMaxHealth(World world) {
     StatBonus equipmentBonus = calculateEquipmentBonuses(world);
     int totalMaxHealth = getMaxHealth() + equipmentBonus.getHealthBonus();
-    
+
     // Apply percentage bonuses
-    double percentageBonus = equipmentBonus.getPercentageBonus("HP") + 
-                           equipmentBonus.getPercentageBonus("Health") +
-                           equipmentBonus.getPercentageBonus("all stats");
+    double percentageBonus =
+        equipmentBonus.getPercentageBonus("HP")
+            + equipmentBonus.getPercentageBonus("Health")
+            + equipmentBonus.getPercentageBonus("all stats");
     if (percentageBonus != 0) {
       totalMaxHealth = (int) Math.round(totalMaxHealth * (1 + percentageBonus / 100.0));
     }
-    
+
     return totalMaxHealth;
   }
 }

--- a/game/src/main/java/avengers/domain/model/Player.java
+++ b/game/src/main/java/avengers/domain/model/Player.java
@@ -1,5 +1,6 @@
 package avengers.domain.model;
 
+import avengers.domain.utils.StatBonus;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,5 +203,96 @@ public final class Player extends Character {
    */
   public String unequipItem(EquipmentSlot slot) {
     return equippedItems.remove(slot);
+  }
+
+  /**
+   * Calculates equipment bonuses for the player based on equipped items.
+   * This method requires a World instance to look up item effects.
+   *
+   * @param world the game world containing item definitions
+   * @return StatBonus object containing all equipment bonuses
+   */
+  public StatBonus calculateEquipmentBonuses(World world) {
+    Map<String, Integer> totalBonuses = new HashMap<>();
+    Map<String, Double> totalPercentageBonuses = new HashMap<>();
+
+    for (String itemId : equippedItems.values()) {
+      if (itemId != null) {
+        world.findItem(itemId).ifPresent(item -> {
+          if (item.hasEffect()) {
+            StatBonus itemBonus = StatBonus.parseEffect(item.getEffect());
+            // Combine flat bonuses
+            itemBonus.getAllBonuses().forEach((stat, bonus) ->
+                totalBonuses.merge(stat, bonus, Integer::sum));
+            // Combine percentage bonuses
+            itemBonus.getAllPercentageBonuses().forEach((stat, bonus) ->
+                totalPercentageBonuses.merge(stat, bonus, Double::sum));
+          }
+        });
+      }
+    }
+
+    return new StatBonus(totalBonuses, totalPercentageBonuses);
+  }
+
+  /**
+   * Gets the total attack including base attack and equipment bonuses.
+   *
+   * @param world the game world to look up equipment effects
+   * @return the total attack value
+   */
+  public int getTotalAttack(World world) {
+    StatBonus equipmentBonus = calculateEquipmentBonuses(world);
+    int totalAttack = getBaseAttack() + equipmentBonus.getAttackBonus();
+    
+    // Apply percentage bonuses
+    double percentageBonus = equipmentBonus.getPercentageBonus("Attack") + 
+                           equipmentBonus.getPercentageBonus("all stats");
+    if (percentageBonus != 0) {
+      totalAttack = (int) Math.round(totalAttack * (1 + percentageBonus / 100.0));
+    }
+    
+    return totalAttack;
+  }
+
+  /**
+   * Gets the total defense including base defense and equipment bonuses.
+   *
+   * @param world the game world to look up equipment effects
+   * @return the total defense value
+   */
+  public int getTotalDefense(World world) {
+    StatBonus equipmentBonus = calculateEquipmentBonuses(world);
+    int totalDefense = getBaseDefense() + equipmentBonus.getDefenseBonus();
+    
+    // Apply percentage bonuses
+    double percentageBonus = equipmentBonus.getPercentageBonus("Defense") + 
+                           equipmentBonus.getPercentageBonus("all stats");
+    if (percentageBonus != 0) {
+      totalDefense = (int) Math.round(totalDefense * (1 + percentageBonus / 100.0));
+    }
+    
+    return totalDefense;
+  }
+
+  /**
+   * Gets the total maximum health including base health and equipment bonuses.
+   *
+   * @param world the game world to look up equipment effects
+   * @return the total maximum health value
+   */
+  public int getTotalMaxHealth(World world) {
+    StatBonus equipmentBonus = calculateEquipmentBonuses(world);
+    int totalMaxHealth = getMaxHealth() + equipmentBonus.getHealthBonus();
+    
+    // Apply percentage bonuses
+    double percentageBonus = equipmentBonus.getPercentageBonus("HP") + 
+                           equipmentBonus.getPercentageBonus("Health") +
+                           equipmentBonus.getPercentageBonus("all stats");
+    if (percentageBonus != 0) {
+      totalMaxHealth = (int) Math.round(totalMaxHealth * (1 + percentageBonus / 100.0));
+    }
+    
+    return totalMaxHealth;
   }
 }

--- a/game/src/main/java/avengers/domain/utils/Verb.java
+++ b/game/src/main/java/avengers/domain/utils/Verb.java
@@ -19,6 +19,7 @@ public enum Verb {
   DEFEND,
   IGNORE,
   HELP,
+  STATS,
   SAVE,
   LOAD,
   QUIT,

--- a/game/src/main/java/avengers/domain/utils/VerbCategory.java
+++ b/game/src/main/java/avengers/domain/utils/VerbCategory.java
@@ -23,7 +23,7 @@ public enum VerbCategory {
       case INVENTORY, PICKUP, DROP, EQUIP, UNEQUIP, USE -> INVENTORY;
       case ACTIVATE, INSPECT, SOLVE, HINT -> INTERACTION;
       case ATTACK, DEFEND, IGNORE -> COMBAT;
-      case HELP, QUIT, SAVE, LOAD, NEW_GAME, UNKNOWN -> SYSTEM;
+      case HELP, STATS, QUIT, SAVE, LOAD, NEW_GAME, UNKNOWN -> SYSTEM;
     };
   }
 }

--- a/game/src/main/java/avengers/service/DefaultExplorationService.java
+++ b/game/src/main/java/avengers/service/DefaultExplorationService.java
@@ -1,0 +1,88 @@
+package avengers.service;
+
+import avengers.domain.model.Item;
+import avengers.domain.model.Player;
+import avengers.domain.model.World;
+import avengers.domain.utils.GameContext;
+import avengers.domain.utils.StatBonus;
+
+/**
+ * Default implementation of ExplorationService for handling exploration-related operations.
+ */
+public class DefaultExplorationService implements ExplorationService {
+
+  @Override
+  public String showStats(GameContext ctx) {
+    Player player = ctx.player();
+    World world = ctx.world();
+    
+    StringBuilder stats = new StringBuilder();
+    stats.append("=== Player Stats ===\n");
+    
+    // Health display
+    stats.append(String.format("Health: %d / %d\n", 
+        player.getCurrentHealth(), player.getTotalMaxHealth(world)));
+    
+    // Attack display
+    int baseAttack = player.getBaseAttack();
+    int totalAttack = player.getTotalAttack(world);
+    int attackBonus = totalAttack - baseAttack;
+    if (attackBonus > 0) {
+      stats.append(String.format("Attack: %d (+%d from equipment) = %d total\n", 
+          baseAttack, attackBonus, totalAttack));
+    } else {
+      stats.append(String.format("Attack: %d\n", baseAttack));
+    }
+    
+    // Defense display
+    int baseDefense = player.getBaseDefense();
+    int totalDefense = player.getTotalDefense(world);
+    int defenseBonus = totalDefense - baseDefense;
+    if (defenseBonus > 0) {
+      stats.append(String.format("Defense: %d (+%d from equipment) = %d total\n", 
+          baseDefense, defenseBonus, totalDefense));
+    } else {
+      stats.append(String.format("Defense: %d\n", baseDefense));
+    }
+    
+    stats.append("\nEquipped Items:\n");
+    
+    // Display equipped items
+    boolean hasEquippedItems = false;
+    for (Player.EquipmentSlot slot : Player.EquipmentSlot.values()) {
+      String itemId = player.getEquippedItem(slot);
+      String itemName = "(none)";
+      
+      if (itemId != null) {
+        Item item = world.findItem(itemId).orElse(null);
+        if (item != null) {
+          itemName = item.getName();
+          hasEquippedItems = true;
+        }
+      }
+      
+      stats.append(String.format("- %s: %s\n", 
+          formatSlotName(slot), itemName));
+    }
+    
+    if (!hasEquippedItems) {
+      stats.append("  No items equipped\n");
+    }
+    
+    return stats.toString();
+  }
+  
+  /**
+   * Formats the equipment slot name for display.
+   *
+   * @param slot the equipment slot
+   * @return formatted slot name
+   */
+  private String formatSlotName(Player.EquipmentSlot slot) {
+    return switch (slot) {
+      case WEAPON -> "Weapon";
+      case ARMOR -> "Armor";
+      case ARTIFACT -> "Artifact";
+    };
+  }
+}

--- a/game/src/main/java/avengers/service/DefaultExplorationService.java
+++ b/game/src/main/java/avengers/service/DefaultExplorationService.java
@@ -4,55 +4,57 @@ import avengers.domain.model.Item;
 import avengers.domain.model.Player;
 import avengers.domain.model.World;
 import avengers.domain.utils.GameContext;
-import avengers.domain.utils.StatBonus;
 
-/**
- * Default implementation of ExplorationService for handling exploration-related operations.
- */
+/** Default implementation of ExplorationService for handling exploration-related operations. */
 public class DefaultExplorationService implements ExplorationService {
 
   @Override
   public String showStats(GameContext ctx) {
     Player player = ctx.player();
     World world = ctx.world();
-    
+
     StringBuilder stats = new StringBuilder();
     stats.append("=== Player Stats ===\n");
-    
+
     // Health display
-    stats.append(String.format("Health: %d / %d\n", 
-        player.getCurrentHealth(), player.getTotalMaxHealth(world)));
-    
+    stats.append(
+        String.format(
+            "Health: %d / %d\n", player.getCurrentHealth(), player.getTotalMaxHealth(world)));
+
     // Attack display
     int baseAttack = player.getBaseAttack();
     int totalAttack = player.getTotalAttack(world);
     int attackBonus = totalAttack - baseAttack;
     if (attackBonus > 0) {
-      stats.append(String.format("Attack: %d (+%d from equipment) = %d total\n", 
-          baseAttack, attackBonus, totalAttack));
+      stats.append(
+          String.format(
+              "Attack: %d (+%d from equipment) = %d total\n",
+              baseAttack, attackBonus, totalAttack));
     } else {
       stats.append(String.format("Attack: %d\n", baseAttack));
     }
-    
+
     // Defense display
     int baseDefense = player.getBaseDefense();
     int totalDefense = player.getTotalDefense(world);
     int defenseBonus = totalDefense - baseDefense;
     if (defenseBonus > 0) {
-      stats.append(String.format("Defense: %d (+%d from equipment) = %d total\n", 
-          baseDefense, defenseBonus, totalDefense));
+      stats.append(
+          String.format(
+              "Defense: %d (+%d from equipment) = %d total\n",
+              baseDefense, defenseBonus, totalDefense));
     } else {
       stats.append(String.format("Defense: %d\n", baseDefense));
     }
-    
+
     stats.append("\nEquipped Items:\n");
-    
+
     // Display equipped items
     boolean hasEquippedItems = false;
     for (Player.EquipmentSlot slot : Player.EquipmentSlot.values()) {
       String itemId = player.getEquippedItem(slot);
       String itemName = "(none)";
-      
+
       if (itemId != null) {
         Item item = world.findItem(itemId).orElse(null);
         if (item != null) {
@@ -60,18 +62,17 @@ public class DefaultExplorationService implements ExplorationService {
           hasEquippedItems = true;
         }
       }
-      
-      stats.append(String.format("- %s: %s\n", 
-          formatSlotName(slot), itemName));
+
+      stats.append(String.format("- %s: %s\n", formatSlotName(slot), itemName));
     }
-    
+
     if (!hasEquippedItems) {
       stats.append("  No items equipped\n");
     }
-    
+
     return stats.toString();
   }
-  
+
   /**
    * Formats the equipment slot name for display.
    *

--- a/game/src/main/java/avengers/service/ExplorationService.java
+++ b/game/src/main/java/avengers/service/ExplorationService.java
@@ -2,9 +2,7 @@ package avengers.service;
 
 import avengers.domain.utils.GameContext;
 
-/**
- * Service interface for handling exploration-related operations including player stats display.
- */
+/** Service interface for handling exploration-related operations including player stats display. */
 public interface ExplorationService {
 
   /**

--- a/game/src/main/java/avengers/service/ExplorationService.java
+++ b/game/src/main/java/avengers/service/ExplorationService.java
@@ -1,0 +1,18 @@
+package avengers.service;
+
+import avengers.domain.utils.GameContext;
+
+/**
+ * Service interface for handling exploration-related operations including player stats display.
+ */
+public interface ExplorationService {
+
+  /**
+   * Generates a formatted display of the player's current stats including health, attack, defense,
+   * and equipped items.
+   *
+   * @param ctx the game context containing player and world information
+   * @return formatted string displaying player stats and equipped items
+   */
+  String showStats(GameContext ctx);
+}

--- a/game/src/test/java/avengers/client/controller/GameControllerTest.java
+++ b/game/src/test/java/avengers/client/controller/GameControllerTest.java
@@ -13,6 +13,8 @@ import avengers.domain.utils.CommandToken;
 import avengers.domain.utils.GameContext;
 import avengers.domain.utils.Verb;
 import avengers.domain.utils.VerbCategory;
+import avengers.service.DefaultExplorationService;
+import avengers.service.ExplorationService;
 import avengers.service.SaveService;
 import avengers.service.spi.FileSaveRepository;
 import avengers.service.world.JsonWorldLoader;
@@ -40,7 +42,8 @@ class GameControllerTest {
 
     SaveService saveService = new SaveService(new FileSaveRepository(Paths.get("test-saves")));
     WorldLoader worldLoader = new JsonWorldLoader();
-    systemController = new SystemController(saveService, worldLoader);
+    ExplorationService explorationService = new DefaultExplorationService();
+    systemController = new SystemController(saveService, worldLoader, explorationService);
     controller = new GameController(controllerMap, systemController);
 
     World world = new World(Map.of(), Map.of(), Map.of(), Map.of(), "room1");
@@ -57,8 +60,10 @@ class GameControllerTest {
   void testControllerCreationWithEmptyMap() {
     SaveService saveService = new SaveService(new FileSaveRepository(Paths.get("test-saves")));
     WorldLoader worldLoader = new JsonWorldLoader();
+    ExplorationService explorationService = new DefaultExplorationService();
     GameController emptyController =
-        new GameController(new HashMap<>(), new SystemController(saveService, worldLoader));
+        new GameController(
+            new HashMap<>(), new SystemController(saveService, worldLoader, explorationService));
 
     assertNotNull(emptyController);
   }

--- a/game/src/test/java/avengers/client/controller/SystemControllerTest.java
+++ b/game/src/test/java/avengers/client/controller/SystemControllerTest.java
@@ -11,6 +11,8 @@ import avengers.domain.utils.CommandResult;
 import avengers.domain.utils.CommandToken;
 import avengers.domain.utils.GameContext;
 import avengers.domain.utils.Verb;
+import avengers.service.DefaultExplorationService;
+import avengers.service.ExplorationService;
 import avengers.service.SaveService;
 import avengers.service.spi.FileSaveRepository;
 import avengers.service.world.JsonWorldLoader;
@@ -30,7 +32,8 @@ class SystemControllerTest {
   void setUp() {
     SaveService saveService = new SaveService(new FileSaveRepository(Paths.get("test-saves")));
     WorldLoader worldLoader = new JsonWorldLoader();
-    controller = new SystemController(saveService, worldLoader);
+    ExplorationService explorationService = new DefaultExplorationService();
+    controller = new SystemController(saveService, worldLoader, explorationService);
     World world = new World(Map.of(), Map.of(), Map.of(), Map.of(), "room1");
     Player player = new Player("TestPlayer", "room1");
     context = new GameContext(world, player);

--- a/game/src/test/java/avengers/domain/utils/VerbTest.java
+++ b/game/src/test/java/avengers/domain/utils/VerbTest.java
@@ -11,7 +11,7 @@ class VerbTest {
   void testVerbValues() {
     Verb[] verbs = Verb.values();
 
-    assertEquals(22, verbs.length);
+    assertEquals(23, verbs.length);
   }
 
   @Test

--- a/game/src/test/java/avengers/service/DefaultExplorationServiceTest.java
+++ b/game/src/test/java/avengers/service/DefaultExplorationServiceTest.java
@@ -1,0 +1,94 @@
+package avengers.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import avengers.domain.model.Item;
+import avengers.domain.model.Player;
+import avengers.domain.model.World;
+import avengers.domain.utils.GameContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class DefaultExplorationServiceTest {
+
+  @Mock private World mockWorld;
+  @Mock private GameContext mockContext;
+
+  private DefaultExplorationService explorationService;
+  private Player player;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    explorationService = new DefaultExplorationService();
+    player = new Player("TestPlayer", "room1");
+    
+    when(mockContext.player()).thenReturn(player);
+    when(mockContext.world()).thenReturn(mockWorld);
+  }
+
+  @Test
+  void showStats_withNoEquipment_displaysBaseStats() {
+    // Given: Player with no equipped items
+    player.setCurrentHealth(85);
+    
+    // When
+    String result = explorationService.showStats(mockContext);
+    
+    // Then
+    assertTrue(result.contains("=== Player Stats ==="));
+    assertTrue(result.contains("Health: 85 / 100"));
+    assertTrue(result.contains("Attack: 10"));
+    assertTrue(result.contains("Defense: 0"));
+    assertTrue(result.contains("Equipped Items:"));
+    assertTrue(result.contains("- Weapon: (none)"));
+    assertTrue(result.contains("- Armor: (none)"));
+    assertTrue(result.contains("- Artifact: (none)"));
+  }
+
+  @Test
+  void showStats_withEquippedItems_displaysItemNames() {
+    // Given: Player with equipped items
+    player.setCurrentHealth(90);
+    player.equipItem(Player.EquipmentSlot.WEAPON, "sword1");
+    player.equipItem(Player.EquipmentSlot.ARMOR, "armor1");
+    
+    Item sword = new Item("sword1", "Iron Sword", "A sturdy iron sword", "Weapon", "+5 Attack", "");
+    Item armor = new Item("armor1", "Leather Vest", "Basic leather armor", "Armor", "+3 Defense", "");
+    
+    when(mockWorld.findItem("sword1")).thenReturn(Optional.of(sword));
+    when(mockWorld.findItem("armor1")).thenReturn(Optional.of(armor));
+    
+    // When
+    String result = explorationService.showStats(mockContext);
+    
+    // Then
+    assertTrue(result.contains("=== Player Stats ==="));
+    assertTrue(result.contains("Health: 90 / 103")); // 100 base + 3 from armor
+    assertTrue(result.contains("Attack: 10 (+5 from equipment) = 15 total"));
+    assertTrue(result.contains("Defense: 0 (+3 from equipment) = 3 total"));
+    assertTrue(result.contains("- Weapon: Iron Sword"));
+    assertTrue(result.contains("- Armor: Leather Vest"));
+    assertTrue(result.contains("- Artifact: (none)"));
+  }
+
+  @Test
+  void showStats_withMissingItem_displaysNone() {
+    // Given: Player with equipped item that doesn't exist in world
+    player.equipItem(Player.EquipmentSlot.WEAPON, "missing_sword");
+    
+    when(mockWorld.findItem("missing_sword")).thenReturn(Optional.empty());
+    
+    // When
+    String result = explorationService.showStats(mockContext);
+    
+    // Then
+    assertTrue(result.contains("- Weapon: (none)"));
+  }
+}

--- a/game/src/test/java/avengers/service/DefaultExplorationServiceTest.java
+++ b/game/src/test/java/avengers/service/DefaultExplorationServiceTest.java
@@ -7,8 +7,6 @@ import avengers.domain.model.Item;
 import avengers.domain.model.Player;
 import avengers.domain.model.World;
 import avengers.domain.utils.GameContext;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +26,7 @@ class DefaultExplorationServiceTest {
     MockitoAnnotations.openMocks(this);
     explorationService = new DefaultExplorationService();
     player = new Player("TestPlayer", "room1");
-    
+
     when(mockContext.player()).thenReturn(player);
     when(mockContext.world()).thenReturn(mockWorld);
   }
@@ -37,10 +35,10 @@ class DefaultExplorationServiceTest {
   void showStats_withNoEquipment_displaysBaseStats() {
     // Given: Player with no equipped items
     player.setCurrentHealth(85);
-    
+
     // When
     String result = explorationService.showStats(mockContext);
-    
+
     // Then
     assertTrue(result.contains("=== Player Stats ==="));
     assertTrue(result.contains("Health: 85 / 100"));
@@ -58,19 +56,20 @@ class DefaultExplorationServiceTest {
     player.setCurrentHealth(90);
     player.equipItem(Player.EquipmentSlot.WEAPON, "sword1");
     player.equipItem(Player.EquipmentSlot.ARMOR, "armor1");
-    
+
     Item sword = new Item("sword1", "Iron Sword", "A sturdy iron sword", "Weapon", "+5 Attack", "");
-    Item armor = new Item("armor1", "Leather Vest", "Basic leather armor", "Armor", "+3 Defense", "");
-    
+    Item armor =
+        new Item("armor1", "Leather Vest", "Basic leather armor", "Armor", "+3 Defense", "");
+
     when(mockWorld.findItem("sword1")).thenReturn(Optional.of(sword));
     when(mockWorld.findItem("armor1")).thenReturn(Optional.of(armor));
-    
+
     // When
     String result = explorationService.showStats(mockContext);
-    
+
     // Then
     assertTrue(result.contains("=== Player Stats ==="));
-    assertTrue(result.contains("Health: 90 / 103")); // 100 base + 3 from armor
+    assertTrue(result.contains("Health: 90 / 100")); // Base health without bonuses for now
     assertTrue(result.contains("Attack: 10 (+5 from equipment) = 15 total"));
     assertTrue(result.contains("Defense: 0 (+3 from equipment) = 3 total"));
     assertTrue(result.contains("- Weapon: Iron Sword"));
@@ -82,12 +81,12 @@ class DefaultExplorationServiceTest {
   void showStats_withMissingItem_displaysNone() {
     // Given: Player with equipped item that doesn't exist in world
     player.equipItem(Player.EquipmentSlot.WEAPON, "missing_sword");
-    
+
     when(mockWorld.findItem("missing_sword")).thenReturn(Optional.empty());
-    
+
     // When
     String result = explorationService.showStats(mockContext);
-    
+
     // Then
     assertTrue(result.contains("- Weapon: (none)"));
   }


### PR DESCRIPTION
## What’s in this PR
Implements a player stats command that displays current health, attack, defense values, and equipped items with equipment bonuses clearly shown.


## Why
Players need visibility into their character's stats and equipped items to make informed gameplay decisions

## How to test
Run the game and use commands stats, status, character, or info to display player statistics. Equip items with stat bonuses (like weapons or armor) and verify the stats display shows base values, equipment bonuses, and totals correctly.

## Checklist
- [ ] Using JDK 21 locally (or `devcontainer` if using VSCode); Gradle wrapper used
- [ ] Branch from `dev`, PR to `dev`
- [ ] Ran `./gradlew spotlessApply` (auto-formatter)
- [ ] `./gradlew clean check` passes locally
- [ ] Tests added/updated for new behavior
- [ ] Brief Javadoc comments included; see [Google Checkstyle Javadoc requirements](https://checkstyle.sourceforge.io/styleguides/google-java-style-20250426/javaguide.html#s7-javadoc)
- [ ] Docs updated if behavior/commands changed (`/docs` and/or README)
- [ ] No game data in views (MVC separation)
- [ ] Linked Issue / Milestone
- [ ] Base is `dev`. Will use **Merge** (not Squash/Rebase).
